### PR TITLE
Fix syntax highlighting for revealing-signing functions

### DIFF
--- a/Syntaxes/spthy.sublime-syntax
+++ b/Syntaxes/spthy.sublime-syntax
@@ -35,7 +35,7 @@ contexts:
     - match: \)
       scope: invalid.illegal.stray-bracket-end
 
-    - match: "\\b(aenc|adec|senc|sdec|sign|verify|Eq|eq|hashing|signing|revealing-signing|diffie-hellman|symmetric-encryption|asymmetric-encryption|multiset|bilinear-pairing|h|H|sk|pk|Fr|In|Out|IN|OUT)\\b"
+    - match: "\\b(aenc|adec|senc|sdec|sign|verify|revealVerify|revealSign|getMessage|true|Eq|eq|hashing|signing|revealing-signing|diffie-hellman|symmetric-encryption|asymmetric-encryption|multiset|bilinear-pairing|h|H|sk|pk|Fr|In|Out|IN|OUT)\\b"
       scope: variable.language.spthy
       comment: Tamarin constr keywords
 


### PR DESCRIPTION
### Have you:

- [x] Followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) document? (It's empty, is this intended?)
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/tamarin-prover/editor-sublime/pulls) for the same update/change?
- [ ] Checked to ensure the plugin compiles and works as expected?

I don't have a Sublime Text license, so someone else must verify this if it is important.

### Description

Add syntax highlighting for `revealSign`, `revealVerify`, `getMessage` and `true`.